### PR TITLE
Improve pause icon and control spacing

### DIFF
--- a/phosphorus.css
+++ b/phosphorus.css
@@ -263,6 +263,7 @@
   width: 32px;
   height: 32px;
   float: right;
+  margin: 0 4px;
   cursor: pointer;
   text-align: center;
   opacity: 0.4;
@@ -311,7 +312,10 @@
   background-size: contain;
   background-position: center;
 }
-.player-root:not([running]) .player-controls .player-pause {
+.player-root[paused] .player-controls .player-pause {
+  background-image: url(Paused.svg);
+}
+.player-root:not([running]):not([paused]) .player-controls .player-pause {
   background-image: url(Go.svg);
 }
 .player-controls .player-turbo {

--- a/phosphorus.dist.js
+++ b/phosphorus.dist.js
@@ -3366,6 +3366,7 @@ var P;
                 }
                 this.stage.runtime.start();
                 this.enableAttribute('running');
+                this.disableAttribute('paused');
                 this.onresume.emit();
             }
             pause() {
@@ -3375,6 +3376,7 @@ var P;
                 }
                 this.stage.runtime.pause();
                 this.disableAttribute('running');
+                this.enableAttribute('paused');
                 this.onpause.emit();
             }
             isRunning() {
@@ -3396,6 +3398,7 @@ var P;
                 this.throwWithoutStage();
                 this.pause();
                 this.stage.runtime.stopAll();
+                this.disableAttribute('paused');
             }
             triggerGreenFlag() {
                 this.throwWithoutStage();
@@ -3409,6 +3412,8 @@ var P;
                 }
             }
             cleanup() {
+                this.disableAttribute('running');
+                this.disableAttribute('paused');
                 if (this.currentLoader) {
                     this.currentLoader.cancel();
                     this.currentLoader = null;

--- a/src/player.ts
+++ b/src/player.ts
@@ -639,6 +639,7 @@ namespace P.player {
       }
       this.stage.runtime.start();
       this.enableAttribute('running');
+      this.disableAttribute('paused');
       this.onresume.emit();
     }
 
@@ -649,6 +650,7 @@ namespace P.player {
       }
       this.stage.runtime.pause();
       this.disableAttribute('running');
+      this.enableAttribute('paused');
       this.onpause.emit();
     }
 
@@ -672,6 +674,7 @@ namespace P.player {
       this.throwWithoutStage();
       this.pause();
       this.stage.runtime.stopAll();
+      this.disableAttribute('paused');
     }
 
     triggerGreenFlag(): void {
@@ -687,6 +690,8 @@ namespace P.player {
     }
 
     cleanup() {
+      this.disableAttribute('running');
+      this.disableAttribute('paused');
       // Stop any loader
       if (this.currentLoader) {
         this.currentLoader.cancel();


### PR DESCRIPTION
## Summary
- space the player control icons apart
- add a `paused` attribute to the player so it can show `Paused.svg`
- use `Paused.svg` when paused

## Testing
- `npm run build`
- `npm test` *(fails: Cannot find module 'playwright')*

------
https://chatgpt.com/codex/tasks/task_e_685574cda25c832587041c55a26d2169