### PR TITLE
Add load error display

### DIFF
--- a/index.css
+++ b/index.css
@@ -100,6 +100,16 @@ input[disabled] {
   background-position-y: -32px;
 }
 
+.load-error {
+  display: none;
+  color: rgb(128, 0, 0);
+  font: 500 12px sans-serif;
+  margin-top: 4px;
+}
+.dark .load-error {
+  color: rgb(255, 91, 91);
+}
+
 .area {
   overflow: hidden;
   margin: 0 -1px;

--- a/index.html
+++ b/index.html
@@ -47,6 +47,7 @@
     <div class="title">
       <input class="url" value="https://scratch.mit.edu/projects/" spellcheck="false">
       <a target="_blank" class="project-link" title="View project on Scratch" rel="noopener" href="https://scratch.mit.edu/"></a>
+      <div id="load-error" class="load-error"></div>
     </div>
 
     <div class="area" id="unshared-projects">
@@ -243,11 +244,27 @@
 
     var player = new P.player.Player();
     player.addControls();
+    var progressContainer = querySelector('.url').parentNode;
     new P.player.ProgressBar(player, {
-      position: querySelector('.url').parentNode,
+      position: progressContainer,
     });
+    var loadError = querySelector('#load-error');
     var errorHandler = new P.player.ErrorHandler(player);
+    player.onstartload.subscribe(function() {
+      loadError.style.display = 'none';
+      loadError.textContent = '';
+    });
+    player.onload.subscribe(function() {
+      loadError.style.display = 'none';
+      loadError.textContent = '';
+    });
+    player.oncleanup.subscribe(function() {
+      loadError.style.display = 'none';
+      loadError.textContent = '';
+    });
     player.onerror.subscribe(function(err) {
+      loadError.textContent = err && err.message ? err.message : String(err);
+      loadError.style.display = 'block';
       if (err instanceof P.player.PlayerError) {
         // Handled by the player's ErrorHandler.
         return;


### PR DESCRIPTION
## Summary
- place an error message container under the progress bar
- style the error container
- show/hide the error message based on player events

## Testing
- `npm test` *(fails: Cannot find module 'playwright')*

------
https://chatgpt.com/codex/tasks/task_e_6855dda6fe688325b23a824a45db2843