### PR TITLE
Add Blockly editor

### DIFF
--- a/editor-page.js
+++ b/editor-page.js
@@ -1,0 +1,33 @@
+(function() {
+  'use strict';
+  var workspace = Blockly.inject('blocklyDiv', {
+    toolbox: document.getElementById('toolbox'),
+    theme: Blockly.Themes.Zelos
+  });
+
+  var player = new P.player.Player();
+  player.addControls();
+  document.getElementById('player').appendChild(player.root);
+
+  var id = location.hash.replace(/^#/, '') || Common.projectId;
+  if (!id) return;
+
+  player.loadProjectById(id).catch(function(e) {
+    console.error(e);
+  });
+
+  fetch('https://projects.scratch.mit.edu/' + id)
+    .then(function(r) { return r.arrayBuffer(); })
+    .then(function(b) { return JSZip.loadAsync(b); })
+    .then(function(zip) { return zip.file('project.json').async('text'); })
+    .then(function(text) {
+      var xml = '<xml><block type="text"><field name="TEXT">' +
+        text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;') +
+        '</field></block></xml>';
+      var dom = Blockly.Xml.textToDom(xml);
+      Blockly.Xml.domToWorkspace(dom, workspace);
+    })
+    .catch(function(err) {
+      console.error(err);
+    });
+})();

--- a/editor.html
+++ b/editor.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>wickphorus editor</title>
+  <link rel="stylesheet" href="phosphorus.css">
+  <link rel="stylesheet" href="index.css">
+  <script src="https://unpkg.com/blockly/blockly.min.js"></script>
+  <style>
+    #editor-container { display: flex; height: 100vh; }
+    #player { width: 480px; margin-right: 8px; }
+    #blocklyDiv { flex: 1; height: 100vh; }
+  </style>
+</head>
+<body>
+  <div id="editor-container">
+    <div id="player"></div>
+    <div id="blocklyDiv"></div>
+  </div>
+  <xml id="toolbox" style="display:none">
+    <block type="text"></block>
+  </xml>
+  <script src="lib/scratch-sb1-converter.js"></script>
+  <script src="lib/jszip.min.js"></script>
+  <script src="lib/fontfaceobserver.standalone.js"></script>
+  <script src="lib/canvg.min.js"></script>
+  <script src="lib/purify.min.js"></script>
+  <script src="phosphorus.dist.js"></script>
+  <script src="common.js"></script>
+  <script src="editor-page.js"></script>
+</body>
+</html>

--- a/editor.js
+++ b/editor.js
@@ -1,0 +1,13 @@
+(function() {
+  'use strict';
+  var seeInside = document.getElementById('see-inside');
+  if (!seeInside) return;
+  seeInside.addEventListener('click', function() {
+    var id = location.hash.replace(/^#/, '');
+    if (id) {
+      location.href = 'editor.html#' + id;
+    } else {
+      alert('Load a project first.');
+    }
+  });
+})();

--- a/index.html
+++ b/index.html
@@ -45,9 +45,11 @@
 
     <div class="area" id="player-area"></div>
 
+
     <div class="title">
       <input class="url" value="https://scratch.mit.edu/projects/" spellcheck="false">
       <a target="_blank" class="project-link" title="View project on Scratch" rel="noopener" href="https://scratch.mit.edu/"></a>
+      <button id="see-inside" type="button">See inside</button>
       <div id="load-error" class="load-error"></div>
     </div>
 
@@ -175,6 +177,7 @@
   <script src="phosphorus.dist.js"></script>
   <script src="common.js"></script>
   <script src="studioview/studioview.js"></script>
+  <script src="editor.js"></script>
 
   <script>
     P.i18n.addTranslations('en', {


### PR DESCRIPTION
## Summary
- add a button that opens a new `editor.html` page
- new page shows the stage next to a large Blockly workspace
- basic script loads the selected project and displays its JSON in the workspace

## Testing
- `npm test` *(fails: Cannot find module 'playwright')*

------
https://chatgpt.com/codex/tasks/task_e_6855e651fb9483259b0dfcc38c5ad1f3